### PR TITLE
Add rotational supports and rotational restraint option to roller supports

### DIFF
--- a/anastruct/fem/plotter/mpl.py
+++ b/anastruct/fem/plotter/mpl.py
@@ -60,6 +60,22 @@ class Plotter(PlottingValues):
             )
             self.one_fig.add_patch(support_patch)
 
+    def __rotational_support_patch(self, max_val):
+        """
+        :param max_val: max scale of the plot
+        """
+        width = height = PATCH_SIZE * max_val
+        for node in self.system.supports_rotational:
+            support_patch = mpatches.Rectangle(
+                (node.vertex.x - width * 0.5, -node.vertex.z - width * 0.5),
+                width,
+                height,
+                color="r",
+                zorder=9,
+                fill=False,
+            )
+            self.one_fig.add_patch(support_patch)
+
     def __roll_support_patch(self, max_val):
         """
         :param max_val: max scale of the plot
@@ -68,12 +84,17 @@ class Plotter(PlottingValues):
         count = 0
         for node in self.system.supports_roll:
             direction = self.system.supports_roll_direction[count]
-            x1 = np.cos(np.pi) * radius + node.vertex.x + radius
-            z1 = np.sin(np.pi) * radius + node.vertex.y
-            x2 = np.cos(np.radians(90)) * radius + node.vertex.x + radius
-            z2 = np.sin(np.radians(90)) * radius + node.vertex.y
-            x3 = np.cos(np.radians(270)) * radius + node.vertex.x + radius
-            z3 = np.sin(np.radians(270)) * radius + node.vertex.y
+            rotate = self.system.supports_roll_rotate[count]
+            x1 = np.cos(np.pi) * radius + node.vertex.x + radius  # vertex.x
+            z1 = np.sin(np.pi) * radius + node.vertex.y  # vertex.y
+            x2 = (
+                np.cos(np.radians(90)) * radius + node.vertex.x + radius
+            )  # vertex.x + radius
+            z2 = np.sin(np.radians(90)) * radius + node.vertex.y  # vertex.y + radius
+            x3 = (
+                np.cos(np.radians(270)) * radius + node.vertex.x + radius
+            )  # vertex.x + radius
+            z3 = np.sin(np.radians(270)) * radius + node.vertex.y  # vertex.y - radius
 
             triangle = np.array([[x1, z1], [x2, z2], [x3, z3]])
 
@@ -87,6 +108,17 @@ class Plotter(PlottingValues):
                     triangle[1:, 1] - 0.5 * radius * np.cos(angle),
                     color="r",
                 )
+                if not rotate:
+                    rect_patch = mpatches.RegularPolygon(
+                        (node.vertex.x, node - node.vertex.y),
+                        numVertices=4,
+                        radius=radius,
+                        orientation=angle,
+                        color="r",
+                        zorder=9,
+                        fill=False,
+                    )
+                    self.one_fig.add_patch(rect_patch)
 
             elif direction == 2:  # horizontal roll
                 support_patch = mpatches.RegularPolygon(
@@ -101,6 +133,16 @@ class Plotter(PlottingValues):
                 self.one_fig.plot(
                     [node.vertex.x - radius, node.vertex.x + radius], [y, y], color="r"
                 )
+                if not rotate:
+                    rect_patch = mpatches.Rectangle(
+                        (node.vertex.x - radius / 2, -node.vertex.z - radius / 2),
+                        radius,
+                        radius,
+                        color="r",
+                        zorder=9,
+                        fill=False,
+                    )
+                    self.one_fig.add_patch(rect_patch)
             elif direction == 1:  # vertical roll
                 # translate the support to the node
 
@@ -113,6 +155,16 @@ class Plotter(PlottingValues):
                     [y, y + 2 * radius],
                     color="r",
                 )
+                if not rotate:
+                    rect_patch = mpatches.Rectangle(
+                        (node.vertex.x - radius / 2, -node.vertex.z - radius / 2),
+                        radius,
+                        radius,
+                        color="r",
+                        zorder=9,
+                        fill=False,
+                    )
+                    self.one_fig.add_patch(rect_patch)
             count += 1
 
     def __rotating_spring_support_patch(self, max_val):
@@ -406,6 +458,7 @@ class Plotter(PlottingValues):
         if supports:
             self.__fixed_support_patch(max_plot_range * scale)
             self.__hinged_support_patch(max_plot_range * scale)
+            self.__rotational_support_patch(max_plot_range * scale)
             self.__roll_support_patch(max_plot_range * scale)
             self.__rotating_spring_support_patch(max_plot_range * scale)
             self.__spring_support_patch(max_plot_range * scale)

--- a/anastruct/fem/postprocess.py
+++ b/anastruct/fem/postprocess.py
@@ -57,6 +57,8 @@ class SystemLevel:
             supports.append(node.id)
         for node in self.system.supports_roll:
             supports.append(node.id)
+        for node in self.system.supports_rotational:
+            supports.append(node.id)
         for node, _ in self.system.supports_spring_x:
             supports.append(node.id)
         for node, _ in self.system.supports_spring_z:

--- a/anastruct/fem/system.py
+++ b/anastruct/fem/system.py
@@ -750,8 +750,9 @@ class SystemElements:
 
         :param node_id: Represents the nodes ID
         :param direction: Represents the direction that is free: 'x', 'y'
-        :param angle Angle in degrees relative to global x-axis.
+        :param angle: Angle in degrees relative to global x-axis.
                                 If angle is given, the support will be inclined.
+        :param rotate: If set to False, rotation at the roller will also be restrained.
         """
         if not isinstance(node_id, collections.Iterable):
             node_id = [node_id]
@@ -1433,7 +1434,7 @@ class SystemElements:
                 last_v = v
 
         # supports
-        for node, direction, angle, rotate in zip(
+        for node, direction, rotate in zip(
             self.supports_roll, self.supports_roll_direction, self.supports_roll_rotate
         ):
             ss.add_support_roll((node.id - 1) * n + 1, direction, None, rotate)

--- a/anastruct/fem/system_components/assembly.py
+++ b/anastruct/fem/system_components/assembly.py
@@ -279,9 +279,22 @@ def process_supports(system):
         set_displacement_vector(system, [(node.id, 1), (node.id, 2)])
 
     for i in range(len(system.supports_roll)):
-        set_displacement_vector(
-            system, [(system.supports_roll[i].id, system.supports_roll_direction[i])]
-        )
+        if not system.supports_roll_rotate[i]:
+            set_displacement_vector(
+                system,
+                [
+                    (system.supports_roll[i].id, system.supports_roll_direction[i]),
+                    (system.supports_roll[i].id, 3),
+                ],
+            )
+        else:
+            set_displacement_vector(
+                system,
+                [(system.supports_roll[i].id, system.supports_roll_direction[i])],
+            )
+
+    for node in system.supports_rotational:
+        set_displacement_vector(system, [(node.id, 3)])
 
     for node in system.supports_fixed:
         set_displacement_vector(system, [(node.id, 1), (node.id, 2), (node.id, 3)])

--- a/anastruct/fem/tests/test.py
+++ b/anastruct/fem/tests/test.py
@@ -334,19 +334,29 @@ class SimpleTest(unittest.TestCase):
     def test_truss_single_hinge(self):
         ss = se.SystemElements(EA=68300, EI=128, mesh=50)
         ss.add_element(
-            location=[[0.0, 0.0], [2.5, 0.0]], g=0, spring={1: 0, 2: 0},
+            location=[[0.0, 0.0], [2.5, 0.0]],
+            g=0,
+            spring={1: 0, 2: 0},
         )
         ss.add_element(
-            location=[[0.0, 0.0], [2.5, 2.0]], g=0, spring={1: 0, 2: 0},
+            location=[[0.0, 0.0], [2.5, 2.0]],
+            g=0,
+            spring={1: 0, 2: 0},
         )
         ss.add_element(
-            location=[[2.5, 0.0], [5.0, 0.0]], g=0, spring={1: 0, 2: 0},
+            location=[[2.5, 0.0], [5.0, 0.0]],
+            g=0,
+            spring={1: 0, 2: 0},
         )
         ss.add_element(
-            location=[[2.5, 2.0], [2.5, 0.0]], g=0, spring={1: 0, 2: 0},
+            location=[[2.5, 2.0], [2.5, 0.0]],
+            g=0,
+            spring={1: 0, 2: 0},
         )
         ss.add_element(
-            location=[[2.5, 2.0], [5.0, 0.0]], g=0, spring={1: 0, 2: 0},
+            location=[[2.5, 2.0], [5.0, 0.0]],
+            g=0,
+            spring={1: 0, 2: 0},
         )
         ss.add_support_hinged(node_id=1)
         ss.add_support_hinged(node_id=4)
@@ -367,14 +377,41 @@ class SimpleTest(unittest.TestCase):
 
     def test_vertical_spring(self):
         ss = se.SystemElements(mesh=250)
-        ss.add_element(location=[(0.0, 0), (10.0, 0)], EA=356000.0, EI=1332.0000000000002)
-        ss.add_support_hinged(node_id=1)
-        ss.add_support_spring(
-            node_id=2, translation=2, k=50, roll=False
+        ss.add_element(
+            location=[(0.0, 0), (10.0, 0)], EA=356000.0, EI=1332.0000000000002
         )
+        ss.add_support_hinged(node_id=1)
+        ss.add_support_spring(node_id=2, translation=2, k=50, roll=False)
         ss.q_load(q=-1.0, element_id=1, direction="y")
         ss.solve()
         self.assertAlmostEqual(0.1, ss.get_node_results_system(2)["uy"])
+
+    def test_rotational_roller_support(self):
+        ss = se.SystemElements()
+        ss.add_element(location=[(0, 0), (0, 1)])
+        ss.add_support_fixed(node_id=1)
+        ss.add_support_roll(node_id=2, direction="x", rotate=False)
+        ss.q_load(q=-1000, element_id=1, direction="x")
+        ss.point_load(node_id=2, Fy=-100)
+        ss.solve()
+        self.assertAlmostEqual(0.0083333, ss.get_node_results_system(2)["ux"])
+        self.assertAlmostEqual(0.0, ss.get_node_results_system(2)["uy"])
+        self.assertAlmostEqual(0.0, ss.get_node_results_system(2)["phi_y"])
+        self.assertAlmostEqual(166.6667083, ss.get_node_results_system(2)["Ty"])
+
+    def test_rotational_support(self):
+        ss = se.SystemElements()
+        ss.add_element(location=[(0, 0), (1, 0)])
+        ss.add_support_fixed(node_id=1)
+        ss.add_support_rotational(node_id=2)
+        ss.q_load(q=-1000, element_id=1, direction="y")
+        ss.point_load(node_id=2, Fx=-100)
+        ss.solve()
+        self.assertAlmostEqual(0.0066667, ss.get_node_results_system(2)["ux"])
+        self.assertAlmostEqual(0.0083333, ss.get_node_results_system(2)["uy"])
+        self.assertAlmostEqual(0.0, ss.get_node_results_system(2)["phi_y"])
+        self.assertAlmostEqual(-166.6667083, ss.get_node_results_system(2)["Ty"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
So I was playing around with anaStruct's code, thinking about column design in particular, and noted that one column type I couldn't analyse in anaStruct (unless I created the full frame) was a sway member that's rotationally-restrained at the top - like the following:
![image](https://user-images.githubusercontent.com/42363318/95417813-b1010f80-0981-11eb-81e0-54bae8e2162a.png)

However, looking at the code, it seemed like this restriction wasn't inherent - it was just there's no frontend function for adding such a support into the stiffness matrix. Playing around briefly, it seems like this PR's code addition just works, and has some value. I've added two types of supports here:
1. `add_support_rotational(node_id)`, which is just a pure rotational restraint, having all translation totally free
2. `add_support_roll(..., rotate=False)`, which extends the existing roller supports to allow for rotationally restraining them as well. It follows the same True/False convention of the `roll=` parameter for springs, but defaults to `True` to maintain previous behaviour by default.

I also added the supports to the native plotting in anaStruct (indicating a rotational restraint by an _unfilled_ rectangle), and added two tests for verifying them. 