### PR TITLE
Fix Nodal Results in Load Combinations with Point or Moment Loads

### DIFF
--- a/anastruct/fem/elements.py
+++ b/anastruct/fem/elements.py
@@ -67,7 +67,9 @@ class Element:
         self.node_id2: int
         self.node_map: Dict[int, Node]
         self.element_displacement_vector: np.ndarray = np.empty(6)
-        self.element_primary_force_vector: np.ndarray = np.zeros(6)  # acting external forces
+        self.element_primary_force_vector: np.ndarray = np.zeros(
+            6
+        )  # acting external forces
         self.element_force_vector: np.ndarray = np.array([])
         self.q_load: float = 0.0
         self.q_direction: Optional[str] = None
@@ -77,7 +79,7 @@ class Element:
         self.bending_moment: Optional[np.ndarray] = None
         self.shear_force: Optional[np.ndarray] = None
         self.deflection: Optional[np.ndarray] = None
-        self.extension = Optional[np.ndarray]
+        self.extension: Optional[np.ndarray] = None
         self.max_deflection = None
         self.nodes_plastic: List[bool] = [False, False]
         self.compile_constitutive_matrix(self.EA, self.EI, l)
@@ -237,14 +239,14 @@ def constitutive_matrix(
 
     if spring is not None:
         """
-        stiffness matrix K: 
+        stiffness matrix K:
         [[ k, k ]
         [ k, k ]]
-        
+
         flexibility matrix C:
         [[ c, c ]    =   [[ 1/k, 1/k ]
         `[ c, c ]]       [  1/k, 1/k ]]
-        
+
         flexibility matrix c + springs on both sides:
         [[ c11 + 1/k1, c12       ]
         [  c21      , c21 + 1/k2 ]]

--- a/anastruct/fem/system_components/assembly.py
+++ b/anastruct/fem/system_components/assembly.py
@@ -39,7 +39,7 @@ def prep_matrix_forces(system: "SystemElements"):
 
 def apply_moment_load(system: "SystemElements"):
     for node_id, Ty in system.loads_moment.items():
-        set_force_vector(system, [(node_id, 3, Ty * system.load_factor)])
+        set_force_vector(system, [(node_id, 3, Ty)])
 
 
 def apply_point_load(system: "SystemElements"):
@@ -49,8 +49,8 @@ def apply_point_load(system: "SystemElements"):
         set_force_vector(
             system,
             [
-                (node_id, 1, Fx * system.load_factor),
-                (node_id, 2, Fz * system.load_factor),
+                (node_id, 1, Fx),
+                (node_id, 2, Fz),
             ],
         )
 

--- a/anastruct/fem/tests/test.py
+++ b/anastruct/fem/tests/test.py
@@ -1,5 +1,6 @@
 import unittest
 from anastruct.fem import system as se
+from anastruct import LoadCase, LoadCombination
 import numpy as np
 from anastruct.fem.examples.ex_8_non_linear_portal import ss as SS_8
 import sys
@@ -411,6 +412,21 @@ class SimpleTest(unittest.TestCase):
         self.assertAlmostEqual(0.0083333, ss.get_node_results_system(2)["uy"])
         self.assertAlmostEqual(0.0, ss.get_node_results_system(2)["phi_y"])
         self.assertAlmostEqual(-166.6667083, ss.get_node_results_system(2)["Ty"])
+
+    def test_load_cases(self):
+        ss = se.SystemElements()
+        ss.add_truss_element(location=[[0, 0], [1000, 0]])
+        ss.add_truss_element(location=[[0, 0], [500, 500]])
+        ss.add_truss_element(location=[[500, 500], [1000, 0]])
+        ss.add_support_hinged(node_id=2)
+        ss.add_support_roll(node_id=1, direction="x", angle=None)
+        lc_dead = LoadCase("dead")
+        lc_dead.point_load(node_id=[1], Fx=10)
+        combination = LoadCombination("ULS")
+        combination.add_load_case(lc_dead, factor=1.4)
+        results = combination.solve(ss)
+        self.assertAlmostEqual(0, results["dead"].get_node_results_system(1)["Fx"])
+        self.assertAlmostEqual(14, results["dead"].get_node_results_system(2)["Fx"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #65 

Store the point loads and moment loads as factored - like q_loads already are - so that `node_results_system()` behaves correctly in computing loads & reactions at nodes.