### PR TITLE
Validation of a simply-supported beam with UDL

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -722,3 +722,35 @@ def describe_end_to_end_tests():
             assert results["combination"].get_node_results_system(5)["Fy"] == approx(
                 wind_Fy + cables_Fy
             )
+
+def describe_analytical_validation_tests():
+    @pspec_context("Validation tests of results, based upon analytical equations")
+    def describe():
+        pass
+
+    def context_simply_supported_beam_validation():
+        @pspec_context("Simply-supported beam with UDL validation")
+        def describe():
+            pass
+
+        w = 1
+        l = 2
+        EI = 10000
+        EA = 1000
+        
+        system = SystemElements(EI=EI, EA=EA, mesh=10000)
+        system.add_element([[0, 0], [l, 0]])
+        system.add_support_hinged([1, 2])
+        system.q_load(w, element_id=1)
+        system.solve()
+
+        def it_results_in_correct_moment_shear():
+            assert system.get_element_results(1)["Mmax"] == approx(w * l**2 / 8)
+            assert system.get_element_results(1)["Qmax"] == approx(w * l / 2)
+
+        def it_results_in_correct_reactions():
+            assert system.get_node_results_system(1)["Fy"] == approx(w * l / 2)
+            assert system.get_node_results_system(2)["Fy"] == approx(w * l / 2)
+
+        def it_results_in_correct_deflections():
+            assert system.get_element_results(1)["wmax"] == approx(-5 * w * l**4 / (384 * EI))

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -723,6 +723,7 @@ def describe_end_to_end_tests():
                 wind_Fy + cables_Fy
             )
 
+
 def describe_analytical_validation_tests():
     @pspec_context("Validation tests of results, based upon analytical equations")
     def describe():
@@ -737,7 +738,7 @@ def describe_analytical_validation_tests():
         l = 2
         EI = 10000
         EA = 1000
-        
+
         system = SystemElements(EI=EI, EA=EA, mesh=10000)
         system.add_element([[0, 0], [l, 0]])
         system.add_support_hinged([1, 2])
@@ -753,4 +754,6 @@ def describe_analytical_validation_tests():
             assert system.get_node_results_system(2)["Fy"] == approx(w * l / 2)
 
         def it_results_in_correct_deflections():
-            assert system.get_element_results(1)["wmax"] == approx(-5 * w * l**4 / (384 * EI))
+            assert system.get_element_results(1)["wmax"] == approx(
+                -5 * w * l**4 / (384 * EI)
+            )


### PR DESCRIPTION
Add a pair-programmed validation of a simply-supported beam