### PR TITLE
Validation with Simply Supported Beam and Two Equally Spaced Point Loads

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -758,6 +758,7 @@ def describe_analytical_validation_tests():
                 -5 * w * l**4 / (384 * EI)
             )
 
+
 def context_simply_supported_two_point_loads():
     @pspec_context("Validation tests of results, based upon analytical equations")
     def describe():

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -757,3 +757,36 @@ def describe_analytical_validation_tests():
             assert system.get_element_results(1)["wmax"] == approx(
                 -5 * w * l**4 / (384 * EI)
             )
+
+
+def describea_analytical_validation_tests():
+    @pspec_context("Validation tests of results, based upon analytical equations")
+    def describe():
+        pass
+
+    p = 80
+    l = 5
+    a = l / 3
+    EI = 14000
+
+    system = SystemElements(EI=EI, mesh=10000)
+    system.add_element([[0, 0], [a, 0]])
+    system.add_element([[a, 0], [2 * a, 0]])
+    system.add_element([[2 * a, 0], [l, 0]])
+    system.add_support_hinged([1, 4])
+    system.point_load(node_id=2, Fy=p)
+    system.point_load(node_id=3, Fy=p)
+    system.solve()
+
+    def it_results_in_correct_moment_shear():
+        assert system.get_element_results(2)["Mmax"] == approx(p * a)
+        assert system.get_element_results(1)["Qmax"] == approx(p)
+
+    def it_results_in_correct_reactions():
+        assert system.get_node_results_system(1)["Fy"] == approx(p)
+        assert system.get_node_results_system(4)["Fy"] == approx(p)
+
+    def it_results_in_correct_deflections():
+        assert system.get_element_results(2)["wmax"] == approx(
+            -((p * a) / (24 * EI)) * (3 * (l**2) - 4 * (a**2))
+        )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -787,6 +787,7 @@ def describea_analytical_validation_tests():
         assert system.get_node_results_system(4)["Fy"] == approx(p)
 
     def it_results_in_correct_deflections():
-        assert system.get_element_results(2)["wmax"] == approx(
+        assert system.get_node_results_system(3)["uy"] + ...
+        system.get_element_results(2)["wmax"] == approx(
             -((p * a) / (24 * EI)) * (3 * (l**2) - 4 * (a**2))
         )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -759,7 +759,7 @@ def describe_analytical_validation_tests():
             )
 
 
-def describea_analytical_validation_tests():
+def context_simply_supported_two_point_loads():
     @pspec_context("Validation tests of results, based upon analytical equations")
     def describe():
         pass
@@ -787,7 +787,6 @@ def describea_analytical_validation_tests():
         assert system.get_node_results_system(4)["Fy"] == approx(p)
 
     def it_results_in_correct_deflections():
-        assert system.get_node_results_system(3)["uy"] + ...
-        system.get_element_results(2)["wmax"] == approx(
-            -((p * a) / (24 * EI)) * (3 * (l**2) - 4 * (a**2))
-        )
+        assert system.get_node_results_system(3)["uy"] + system.get_element_results(2)[
+            "wmax"
+        ] == approx(-((p * a) / (24 * EI)) * (3 * (l**2) - 4 * (a**2)))


### PR DESCRIPTION
Added analytical test case to teste2e.py using below beam table. Note that the deflection is only matching when adding both the element and node deflections as the maximum deflection of the beam is in the middle. 

![image](https://user-images.githubusercontent.com/97464910/223556913-ef245729-b854-4635-ba3d-9c0ed105d90d.png)
