### PR TITLE
Added validation cases

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -857,7 +857,9 @@ def context_fixed_ends_beam_point_load_validation():
 
 
 def context_3_span_continuous_beam_2_UDL_loads_validation():
-    @pspec_context("Beam fixed at both ends with concentrated load at center")
+    @pspec_context(
+        "Continuous Beam spanning over three supports with two UDL in the outer spans"
+    )
     def describe():
         pass
 


### PR DESCRIPTION
Added two test cases from standard beam tables. 

![image](https://user-images.githubusercontent.com/97464910/226078478-b107ad67-c63c-497f-b1e3-0823328cf777.png)
- Node added at x = 3 to check for maximum moments and deflection at point

![image](https://user-images.githubusercontent.com/97464910/226078507-158fd36e-4407-4563-bc09-12218708c7f4.png)
- While the image above shows moment and deflection approximation, calculated approximate values were slightly off. A more accurate "coefficient" was back-calculated to converge towards the calculated answer, only involving adding significant figures. 