### PR TITLE
Fixing problem with show_shear_force(values_only=True)

### DIFF
--- a/anastruct/fem/plotter/values.py
+++ b/anastruct/fem/plotter/values.py
@@ -170,7 +170,11 @@ class PlottingValues:
         if factor is None:
             max_force = max(
                 map(
-                    lambda el: np.max(np.abs(el.shear_force or 0.0)),
+                    lambda el: (
+                        np.max(np.abs(el.shear_force or 0.0))
+                        if el.shear_force is not None
+                        else 0.0
+                    ),
                     self.system.element_map.values(),
                 )
             )
@@ -179,6 +183,7 @@ class PlottingValues:
             [
                 plot_values_shear_force(el, factor)
                 for el in self.system.element_map.values()
+                if el.shear_force is not None
             ]
         )
         return xy[0, :], xy[1, :]


### PR DESCRIPTION
When using values_only=True, the following error is thrown:

site-packages\anastruct\fem\plotter\values.py", line 173, in <lambda>
    lambda el: np.max(np.abs(el.shear_force or 0.0)),
                             ^^^^^^^^^^^^^^^^^^^^^
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

This code fixes that, and the expected values are returned.

I have not tested this beyond a very simple system:
```
from anastruct import SystemElements


ss = SystemElements()

# Define the geometry
length = 10
ss.add_element(location=[[0, 0], [length, 0]], EA=10000, EI=1000000)

# Add supports
ss.add_support_hinged(node_id=1)
ss.add_support_roll(node_id=2, direction=2)

# Add loads
ss.q_load(element_id=1, q=-10)

# Solve the system
ss.solve()

# Get min/max values

max_bending_moment = ss.get_element_results(element_id=1)["Mmax"]
min_bending_moment = ss.get_element_results(element_id=1)["Mmin"]
max_shear_force = ss.get_element_results(element_id=1)["Qmax"]
min_shear_force = ss.get_element_results(element_id=1)["Qmin"]
max_axial_force = ss.get_element_results(element_id=1)["Nmax"]
min_axial_force = ss.get_element_results(element_id=1)["Nmin"]
max_displacement = ss.get_element_results(element_id=1)["wmax"]
min_displacement = ss.get_element_results(element_id=1)["wmin"]


support_locations = [0, 10]
support_reactions = []
element_ids = [1]

for node_id in range(1, len(support_locations) + 1):

    # Get results for the current node
    node_results = ss.get_node_results_system(node_id=node_id)
    
    # Convert values to float
    formatted_results = {
        "id": node_results["id"],
        "Fx": float(node_results["Fx"]),
        "Fy": float(node_results["Fy"]),
        "Tz": float(node_results["Tz"]),
        "ux": float(node_results["ux"]),
        "uy": float(node_results["uy"]),
        "phi_z": float(node_results["phi_z"]),
    }
    
    support_reactions.append(formatted_results)

print(support_reactions)
print(max_bending_moment, min_bending_moment, max_shear_force, min_shear_force, max_axial_force, min_axial_force, max_displacement, min_displacement)

bending_x_values = ss.show_bending_moment(values_only=True)[0]
print(f"Bending x_values:{bending_x_values}")
shear_x_values = ss.show_shear_force(values_only=True)
print(f"Shear x_values:{shear_x_values}")
```
